### PR TITLE
JL8-20 chore : 플리 디테일 페이지에서는 곡 수가 아닌 가수 명을 표시

### DIFF
--- a/src/app/playlist/_components/Playlist.tsx
+++ b/src/app/playlist/_components/Playlist.tsx
@@ -54,10 +54,11 @@ export default function Playlist({ initialPlaylists }: PlaylistComponentProps) {
       isOpen: true,
       title: '완료',
       content: '플레이리스트가 추가되었습니다!',
-      onConfirm: () =>
-        setSuccessModalProps((prev) => ({ ...prev, isOpen: false })),
+      onConfirm: () => {
+        setSuccessModalProps((prev) => ({ ...prev, isOpen: false }))
+        closeModal()
+      },
     })
-    closeModal()
   })
 
   const updatePlaylistMutation = useUpdatePlaylist(() => {
@@ -65,10 +66,11 @@ export default function Playlist({ initialPlaylists }: PlaylistComponentProps) {
       isOpen: true,
       title: '완료',
       content: '플레이리스트가 수정되었습니다!',
-      onConfirm: () =>
-        setSuccessModalProps((prev) => ({ ...prev, isOpen: false })),
+      onConfirm: () => {
+        setSuccessModalProps((prev) => ({ ...prev, isOpen: false }))
+        closeModal()
+      },
     })
-    closeModal()
   })
 
   useEffect(() => {
@@ -196,7 +198,7 @@ export default function Playlist({ initialPlaylists }: PlaylistComponentProps) {
                 user_id: user?.id || '',
               } as PlaylistInsert)
             } else if (modalType === 'edit' && selectedPlaylist) {
-              updatePlaylistMutation.mutate({
+              updatePlaylistMutation.mutateAsync({
                 id: selectedPlaylist.id,
                 updatedData: {
                   name,

--- a/src/components/common/PlaylistItem.tsx
+++ b/src/components/common/PlaylistItem.tsx
@@ -82,9 +82,13 @@ export default function PlaylistItem({
         </div>
         <div className="flex w-full flex-col justify-center">
           <p className="button-2 mb-1">{playlist.name || '제목 없음'}</p>
-          <p className="caption-2 text-opacity-60">
-            곡{playlist?.song_count ?? 0}개
-          </p>
+          {isDetailPage ? (
+            <p className="caption-2 text-opacity-60">{playlist.description}</p>
+          ) : (
+            <p className="caption-2 text-opacity-60">
+              곡 {playlist?.song_count ?? 0}개
+            </p>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## 🔘 Part

플레이 리스트 페이지

## 📝 작업 내용

> 앱 화면에서 플리 디테일 페이지에선 곡 수가 아닌 아티스트 명으로 표시

## 🖼️ 스크린샷 (선택)

> UI 변경이 있다면, 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## 🔧 해야 할 일

- [ ] button 만들기
